### PR TITLE
Fix loadBooks to createBook for USFM files only

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -73,7 +73,9 @@ function loadBooks(dir, lang) {
   }).then( fileNames => {
 
     return Promise.all(
-      fileNames.map( fileName => {
+      fileNames
+      .filter(fileName => fileName.endsWith('.USFM') || fileName.endsWith('.usfm'))
+      .map( fileName => {
         var filePath = path.join(dir, fileName);
         return createBook(filePath, lang);
       })


### PR DESCRIPTION
Tried calling the getBooks method for a parser I instantiated with a git repository containing USFM files, README.md, .git folder. Then I would get the error below.

<img width="655" alt="Screenshot 2021-02-10 at 3 42 58 PM" src="https://user-images.githubusercontent.com/74678465/107514602-f137ff00-6bba-11eb-8a87-fad85fd82db1.png">

Upon looking at the code, it was apparent why I got the error. The code assumed that the inputDir used during instantiation of the parser only contained USFM files.

This pull request, should it get accepted, seeks to allow the parser to only scan for files with the extension '.USFM' or '.usfm'.